### PR TITLE
Fix GroupManager Batch Recall: Exclude Command, Ignore Admins/Owners,…

### DIFF
--- a/app/modules/GroupManager/handlers/handle_response.py
+++ b/app/modules/GroupManager/handlers/handle_response.py
@@ -10,6 +10,11 @@ import re
 # value: messages 列表
 TEMP_GROUP_HISTORY_CACHE = {}
 
+# 临时缓存：用于存储通过echo标识获取到的群成员列表（用于批量撤回时过滤管理员/群主）
+# key: 完整的echo字符串（如 get_group_member_list-group_id={group_id}-{note}）
+# value: 群成员列表数据
+TEMP_GROUP_MEMBERS_CACHE = {}
+
 
 class ResponseHandler:
     """响应处理器"""
@@ -86,6 +91,13 @@ class ResponseHandler:
                 # 发送消息
                 await send_group_msg(self.websocket, group_id, message)
 
+            # 缓存用于撤回的群成员列表（用于识别admin/owner）
+            elif (
+                isinstance(self.echo, str)
+                and self.echo.startswith("get_group_member_list-")
+                and f"{MODULE_NAME}-recall" in self.echo
+            ):
+                TEMP_GROUP_MEMBERS_CACHE[self.echo] = self.data
         except Exception as e:
             logger.error(f"[{MODULE_NAME}]获取群成员列表失败: {e}")
 


### PR DESCRIPTION
… Limit to 10 (#2)

* fix(GroupManager): batch recall skips command, ignores admin/owner, and limits count

Update the batch recall feature in GroupManager to not recall the recall command itself, skip messages from users with admin/owner roles, and restrict actual deleted messages to a maximum of 10. This improves correctness and conforms better to admin intent.

- Fetch N+1 messages to exclude the recall command itself from being deleted
- Cross-check with group member list to ignore admin/owner roles when recalling
- Limit actual recall action to 10 messages max, regardless of input
- Minor refactor to cache group member info for robust role checking

No breaking changes; improves precision and expected behavior for group admins.

* feat(GroupManagerHandle.py): 取消批量撤回数量上限

- 移除了批量撤回指令的数量上限，允许按请求数量全部撤回
- 保持过滤admin/owner消息和指令自身消息的处理规范
- 优化用户体验，以更灵活地满足群管理批量操作需求

* refactor(GroupManager): remove group member list query from batch recall

Use sender.role in message history to identify group owner/admin when filtering recall targets, eliminating unnecessary group member list fetches. This makes recall logic more efficient and reduces redundant requests.
- No longer queries and caches member list for recall batch actions
- Uses 'role' in message history sender field for admin/owner judgment

---------